### PR TITLE
cx231xx-dev: TBS 5990 working with two adapters

### DIFF
--- a/drivers/media/dvb-frontends/tas2101.c
+++ b/drivers/media/dvb-frontends/tas2101.c
@@ -57,20 +57,25 @@ EXPORT_SYMBOL_GPL(tas2101_get_i2c_adapter);
 /* the first value is the starting address */
 static int tas2101_wrm(struct tas2101_priv *priv, u8 *buf, int len)
 {
-	int ret;
+	int ret, i;
+	u8 sbuf[] = { buf[0], buf[1] };
 	struct i2c_msg msg = {
 		.addr = priv->cfg->i2c_address,
-		.flags = 0, .buf = buf, .len = len };
+		.flags = 0, .buf = sbuf, .len = 2 };
 
 	dev_dbg(&priv->i2c->dev, "%s() i2c wrm @0x%02x (len=%d)\n",
 		__func__, buf[0], len);
 
-	ret = i2c_transfer(priv->i2c_demod, &msg, 1);
-	if (ret < 0) {
-		dev_warn(&priv->i2c->dev,
-			"%s: i2c wrm err(%i) @0x%02x (len=%d)\n",
-			KBUILD_MODNAME, ret, buf[0], len);
-		return ret;
+	for (i = 1; i < len; ++i ) {
+		ret = i2c_transfer(priv->i2c_demod, &msg, 1);
+		if (ret < 0) {
+			dev_warn(&priv->i2c->dev,
+				"%s: i2c wrm err(%i) @0x%02x (len=%d)\n",
+				KBUILD_MODNAME, ret, buf[0], len);
+			return ret;
+		}
+		++sbuf[0];
+		sbuf[1] = buf[i+1];
 	}
 	return 0;
 }

--- a/drivers/media/tuners/av201x.c
+++ b/drivers/media/tuners/av201x.c
@@ -24,20 +24,25 @@
 /* write multiple (continuous) registers */
 static int av201x_wrm(struct av201x_priv *priv, u8 *buf, int len)
 {
-	int ret;
+	int ret, i;
+	u8 sbuf[] = { buf[0], buf[1] };
 	struct i2c_msg msg = {
 		.addr = priv->cfg->i2c_address,
-		.flags = 0, .buf = buf, .len = len };
+		.flags = 0, .buf = sbuf, .len = 2 };
 
 	dev_dbg(&priv->i2c->dev, "%s() i2c wrm @0x%02x (len=%d) ",
 		__func__, buf[0], len);
 
-	ret = i2c_transfer(priv->i2c, &msg, 1);
-	if (ret < 0) {
-		dev_warn(&priv->i2c->dev,
-			"%s: i2c wrm err(%i) @0x%02x (len=%d)\n",
-			KBUILD_MODNAME, ret, buf[0], len);
-		return ret;
+	for (i = 1; i < len; ++i ) {
+		ret = i2c_transfer(priv->i2c, &msg, 1);
+		if (ret < 0) {
+			dev_warn(&priv->i2c->dev,
+				"%s: i2c wrm err(%i) @0x%02x (len=%d)\n",
+				KBUILD_MODNAME, ret, buf[0], len);
+			return ret;
+		}
+		++sbuf[0];
+		sbuf[1] = buf[i+1];
 	}
 	return 0;
 }

--- a/drivers/media/usb/cx231xx/cx231xx-cards.c
+++ b/drivers/media/usb/cx231xx/cx231xx-cards.c
@@ -944,7 +944,7 @@ struct cx231xx_board cx231xx_boards[] = {
 		.demod_i2c_master = I2C_1_MUX_3,
 		.has_dvb = 1,
 		.adap_cnt = 2,
-		.demod_addr = 0x6c,
+		.demod_addr = 0x64,
 		.norm = V4L2_STD_PAL_M,
 		
 		.input = {{

--- a/drivers/media/usb/cx231xx/cx231xx-dvb.c
+++ b/drivers/media/usb/cx231xx/cx231xx-dvb.c
@@ -1175,9 +1175,6 @@ static int dvb_init(struct cx231xx *dev)
 			goto out_free;
 		}
 
-		/* define general-purpose callback pointer */
-		dvb->frontend->callback = cx231xx_tuner_callback;
-
 		/* attach tuner */
 		if (dvb_attach(av201x_attach, dev->dvb[i]->frontend, &tbs5990_av201x_cfg,
 			tas2101_get_i2c_adapter(dev->dvb[i]->frontend, 2)) == NULL) {
@@ -1185,7 +1182,12 @@ static int dvb_init(struct cx231xx *dev)
 			result = -ENODEV;
 			goto out_free;
 		}
-	
+
+		msleep(100);
+
+		/* define general-purpose callback pointer */
+		dvb->frontend->callback = cx231xx_tuner_callback;
+
 		break;
 	}
 	default:


### PR DESCRIPTION
I haven't tested those branch but the commits run on my ARM box with kernel 3.14.

The crucial part is to send buffers via i2c as single bytes to avoid the broken pipe (-32) error. Both fixes to av201x and tas2101 make the second adapter work. I don't know about performance impact but it should not be significant.

Furthermore I attempted to fix the deadlock in case of an initialization error and de-initialize the CI interface if the dvb interface is removed. That allows reloadint the driver.